### PR TITLE
Enable using multiple LLM-compatible clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ temp/
 # Development file uploads and data
 /public/uploads/
 data/model-images.json
+
+.env.local

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ npm install
 3. Configure environment variables:
 Create a `.env.local` file with the following:
 ```env
-OPENROUTER_API_KEY=your_openrouter_api_key_here
+LLM_CLIENT_ENDPOINT=your_llm_client_endpoint_here
+LLM_CLIENT_MODAL=your_llm_client_model_here
+LLM_CLIENT_API_KEY=your_llm_client_api_key_here
 FASHN_API_KEY=your_fashn_api_key_here
 
 # Real-Time Amazon Data API Credentials
@@ -235,13 +237,25 @@ src/
 ## Configuration
 
 ### Environment Variables
-- `OPENROUTER_API_KEY`: Authentication key for OpenRouter API (replaces LLAMA_API_KEY)
+- `LLM_CLIENT_ENDPOINT`: API endpoint for llm client
+
+      - For OpenRouter, use https://openrouter.ai/api/v1
+      - For Groq, use https://api.groq.com/openai/v1
+
+- `LLM_CLIENT_MODAL`: Open IA Modal
+
+      - For OpenRouter, use 'google/gemini-2.5-flash'
+      - For Groq, use 'meta-llama/llama-4-scout-17b-16e-instruct'
+
+- `LLM_CLIENT_API_KEY`: Authentication key for LLM Client API
 - `FASHN_API_KEY`: Authentication key for Fashion API services
 - `RAPIDAPI_KEY`: Authentication key for Amazon product API
 - `RAPIDAPI_HOST`: API host endpoint for product search
 
 ### Model Configuration
-The application uses Gemini 2.5 Flash via OpenRouter with custom system prompts optimized for:
+The application can use multiple modal via OpenRouter, Groq, etc...
+
+It recommands to use Gemini 2.5 Flash via OpenRouter with custom system prompts optimized for:
 - Fashion styling expertise
 - Focus on tops and bottoms (excluding accessories)
 - Professional styling advice

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -15,18 +15,18 @@ export const maxDuration = 30;
 const vercelURL = process.env.VERCEL_URL;
 const appURL = vercelURL ? `https://${vercelURL}` : 'http://localhost:3000';
 
-// Configure OpenAI client to use OpenRouter
-const openRouterClient = createOpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: process.env.OPENROUTER_API_KEY,
+// Configure OpenAI client to use llmClient
+const llmClient = createOpenAI({
+  baseURL: process.env.LLM_CLIENT_ENDPOINT,
+  apiKey: process.env.LLM_CLIENT_API_KEY,
   headers: {
     'HTTP-Referer': appURL,
     'X-Title': 'OpenAI Stylist',
   },
 });
 
-// Model to use for all requests - Gemini 2.5 Flash has excellent vision and reasoning capabilities
-const MODEL_NAME = 'google/gemini-2.5-flash';
+// Model to use for all requests
+const MODEL_NAME = process.env.LLM_CLIENT_MODAL;
 
 // We no longer need local product catalog since we're using real Amazon API
 
@@ -171,7 +171,7 @@ export async function POST(req: Request) {
 
         // Use normal AI SDK flow with the enhanced text message
         const result = streamText({
-          model: openRouterClient(MODEL_NAME),
+          model: llmClient(MODEL_NAME),
           system: `You are "StyleList", a professional AI fashion stylist. The user has provided an image which has been analyzed for you.
 
 **Gender-Aware Styling:**
@@ -212,7 +212,7 @@ CRITICAL:
     console.log(`[api/chat] Using AI SDK for text-only messages`);
 
     const result = streamText({
-      model: openRouterClient(MODEL_NAME),
+      model: llmClient(MODEL_NAME),
 
       system: `You are "StyleList", a professional AI fashion stylist.
 

--- a/src/app/api/generate-moodboard/route.ts
+++ b/src/app/api/generate-moodboard/route.ts
@@ -18,9 +18,9 @@ const vercelURL = process.env.VERCEL_URL;
 const appURL = vercelURL ? `https://${vercelURL}` : 'http://localhost:3000';
 
 // FIX: Point the baseURL to the new /api/v1 path.
-const openRouterClient = createOpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: process.env.OPENROUTER_API_KEY,
+const llmClient = createOpenAI({
+  baseURL: process.env.LLM_CLIENT_ENDPOINT,
+  apiKey: process.env.LLM_CLIENT_API_KEY,
   headers: {
     'HTTP-Referer': appURL,
     'X-Title': 'OpenAI Stylist',
@@ -28,7 +28,7 @@ const openRouterClient = createOpenAI({
 });
 
 // Model to use for all requests
-const MODEL_NAME = 'google/gemini-2.5-flash';
+const MODEL_NAME = process.env.LLM_CLIENT_MODAL;
 
 // Correct: Define a schema for the categorization result
 const categorizationSchema = z.object({
@@ -115,7 +115,7 @@ export async function POST(req: Request) {
         const prompt = `A user has selected these items: "${productDescriptions}". Their boards are: ${boardSummaries || 'None'}. Decide if they fit an existing board or need a new one.`;
 
         const { object: categorizationResult } = await generateObject({
-            model: openRouterClient(MODEL_NAME),
+            model: llmClient(MODEL_NAME),
             schema: categorizationSchema,
             system: 'You are a fashion stylist helping organize moodboards. You decide whether to add products to an existing mood board or create a new one based on style coherence.',
             prompt: `You have these existing mood boards:

--- a/src/app/api/proactive-style-generator/route.ts
+++ b/src/app/api/proactive-style-generator/route.ts
@@ -16,9 +16,9 @@ export const maxDuration = 180; // Allow 3 minutes for the full background proce
 const vercelURL = process.env.VERCEL_URL;
 const appURL = vercelURL ? `https://${vercelURL}` : 'http://localhost:3000';
 
-const openRouterClient = createOpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: process.env.OPENROUTER_API_KEY,
+const llmClient = createOpenAI({
+  baseURL: process.env.LLM_CLIENT_ENDPOINT,
+  apiKey: process.env.LLM_CLIENT_API_KEY,
   headers: {
     'HTTP-Referer': appURL,
     'X-Title': 'OpenAI Stylist',
@@ -26,7 +26,7 @@ const openRouterClient = createOpenAI({
 });
 
 // Model to use for all requests
-const MODEL_NAME = 'google/gemini-2.5-flash';
+const MODEL_NAME = process.env.LLM_CLIENT_MODAL;
 
 // Zod schemas for AI-driven decisions
 const searchQueriesSchema = z.object({
@@ -60,7 +60,7 @@ async function runProactiveStyling(adviceText: string, mode: "performance" | "ba
   try {
     // 1. AI analyzes its own advice to decide what to search for
     const { object: searchDecision } = await generateObject({
-      model: openRouterClient(MODEL_NAME),
+      model: llmClient(MODEL_NAME),
       schema: searchQueriesSchema,
       system: "You are a fashion assistant. Your job is to read styling advice and extract 1-2 key, specific clothing items to create a style board from. Focus on unique, actionable items. Always detect the gender context (men/women/unisex) and include appropriate gender-specific search terms.",
       prompt: `Here is the styling advice. Extract the best items for a visual search and detect the gender context:
@@ -86,7 +86,7 @@ ${adviceText}`,
 
     // 3. AI generates title & description for the new board
     const { object: boardDetails } = await generateObject({
-      model: openRouterClient(MODEL_NAME),
+      model: llmClient(MODEL_NAME),
       schema: boardDetailsSchema,
       system: "You are a creative director who creates catchy titles and descriptions for fashion mood boards.",
       prompt: `Create a short, catchy title and description for a mood board based on these styling elements:


### PR DESCRIPTION
Introduced a new environment variables: 
- **LLM_CLIENT_ENDPOINT** → This allows dynamic selection of the API endpoint.
- **LLM_CLIENT_MODAL** → This allows dynamic selection of the LLM modal.
- **LLM_CLIENT_API_KEY** → Authentication key for LLM Client API.

=> Adjusted API call logic to use this variable, making the client behavior provider-agnostic.
- `LLM_CLIENT_ENDPOINT`: API endpoint for llm client

      - For OpenRouter, use https://openrouter.ai/api/v1
      - For Groq, use https://api.groq.com/openai/v1

- `LLM_CLIENT_MODAL`: Open IA Modal

      - For OpenRouter, use 'google/gemini-2.5-flash'
      - For Groq, use 'meta-llama/llama-4-scout-17b-16e-instruct'

- `LLM_CLIENT_API_KEY`: Authentication key for LLM Client API